### PR TITLE
Initialize $allowed_projects as empty array

### DIFF
--- a/HideEconsentFramework.php
+++ b/HideEconsentFramework.php
@@ -10,7 +10,7 @@ class HideEconsentFramework extends \ExternalModules\AbstractExternalModule
     function redcap_every_page_top(int $project_id)
     {
         $allowlist = $this->getSubSettings('allowlist');
-        $allowed_projects = null;
+        $allowed_projects = [];
 
         foreach ($allowlist as $allowed) {
             $allowed_projects[] = intval($allowed['project-id']);


### PR DESCRIPTION
- Bug fix: If the allowlist was empty, a TypeError was thrown (ticket #1).